### PR TITLE
Fix AttributeError for engine_channel

### DIFF
--- a/main.py
+++ b/main.py
@@ -26,8 +26,10 @@ class Game:
         try:
             pygame.mixer.init()
             self.sound_enabled = True
+            self.engine_channel = pygame.mixer.Channel(0)
         except pygame.error:
             self.sound_enabled = False
+            self.engine_channel = None
             print("Warning: Could not initialize sound mixer.")
 
         self.display_width = DISPLAY_WIDTH
@@ -247,8 +249,7 @@ class Game:
             return 1
 
     def game_loop(self):
-        if self.assets['sounds'] and not pygame.mixer.music.get_busy():
-            self.engine_channel = pygame.mixer.Channel(0)
+        if self.sound_enabled and self.assets['sounds']:
             self.engine_channel.play(self.assets['sounds']['engine'], -1)
 
         while self.game_state == 'PLAYING':


### PR DESCRIPTION
This commit fixes a critical bug that caused the game to crash with an `AttributeError: 'Game' object has no attribute 'engine_channel'`.

The error occurred after a player crashed and lost a life, because the sound channel for the engine was not being correctly re-initialized.

The fix involves:
- Initializing `self.engine_channel` in the `Game.__init__` method to ensure it exists for the lifetime of the game object.
- Simplifying the logic in the `game_loop` that starts the engine sound.

This change makes the game more robust and prevents the crash reported by the user.