### PR TITLE
Adjust explosion graphic size

### DIFF
--- a/main.py
+++ b/main.py
@@ -81,9 +81,10 @@ class Game:
         }
         try:
             boom_image = pygame.image.load('boom.jpg')
-            width = boom_image.get_width()
-            height = boom_image.get_height()
-            assets['boom'] = pygame.transform.scale(boom_image, (width // 2, height // 2))
+            # Get the size of a sample enemy car
+            car_width = assets['obstacle_cars'][0].get_width()
+            car_height = assets['obstacle_cars'][0].get_height()
+            assets['boom'] = pygame.transform.scale(boom_image, (car_width, car_height))
             assets['boom'].set_alpha(128)
         except (pygame.error, FileNotFoundError):
             assets['boom'] = None


### PR DESCRIPTION
This commit adjusts the size of the explosion graphic (`boom.jpg`) to match the size of an enemy car, as requested by the user.

The `load_assets` method now dynamically gets the dimensions of a sample enemy car and scales the explosion graphic to match. The semi-transparency of the graphic is maintained.